### PR TITLE
Changing package manger logic, Adding dnf5

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,12 @@
 ---
-- name: 'Ensure Google Chrome is provisioned for package manager ({{ ansible_pkg_mgr }})'
-  include_tasks: 'tasks-{{ ansible_pkg_mgr }}.yml'
-  when: ansible_pkg_mgr in ('apt', 'dnf')
+- name: 'Ensure Google Chrome is provisioned for package manager dnf'
+  include_tasks: 'tasks-dnf.yml'
+  when: ansible_pkg_mgr in ('dnf5', 'dnf')
+
+- name: 'Ensure Google Chrome is provisioned for package manager apt'
+  include_tasks: 'tasks-apt.yml'
+  when: ansible_pkg_mgr in ('apt')
 
 - fail:
     msg: ERROR This role is not setup to deal with package manager {{ ansible_pkg_mgr }}
-  when: ansible_pkg_mgr not in ('apt', 'dnf')
+  when: ansible_pkg_mgr not in ('apt', 'dnf', 'dnf5')


### PR DESCRIPTION
For Nobara 40 compatibility, its ansible_pkg_mgr is 'dnf5' which did not work with the prior logic, this diverts 'dnf' and 'dnf5' to the same dnf based tasks while keeping apt tasks separate 